### PR TITLE
List iOS 15 as a supported platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "HNAPI", platforms: [.macOS(.v12)],
+    name: "HNAPI", platforms: [.macOS(.v12), .iOS(.v15)],
     products: [.library(name: "HNAPI", targets: ["HNAPI"])],
     dependencies: [.package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.0.0")],
     targets: [.target(name: "HNAPI", dependencies: ["SwiftSoup"], path: "Sources")])


### PR DESCRIPTION
Thank you for providing this lovely little library!

I wanted to play with it in an iOS app but Xcode gave me an error on [this line](https://github.com/goranmoomin/HNAPI/blob/322f2cb8e5c0f1fc468f33d6189da26da479b793/Sources/NetworkClient.swift#L58) about iOS 15 compatibility:

> `data(from:delegate:)` is only available in iOS 15.0 or newer

Specifying greater-than-or-equal-to iOS 15 compatibility in the package file got rid of the error.